### PR TITLE
[gac] feat(User): Add UserDataInitializer for initializing user data

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,1 +1,0 @@
-.\mvnw spring-boot:run

--- a/src/main/java/scrumbackend/issue/Issue.java
+++ b/src/main/java/scrumbackend/issue/Issue.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.sql.Date;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import scrumbackend.scrum.Scrum;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -37,8 +39,10 @@ public class Issue {
   private Date updatedAt;
 
   private String issuesToday;
-  private String issuesYesterday;
 
   @Builder.Default
   private boolean isResolved = false;
+
+  @OneToOne(mappedBy = "issue")
+  private Scrum scrum;
 }

--- a/src/main/java/scrumbackend/scrum/Scrum.java
+++ b/src/main/java/scrumbackend/scrum/Scrum.java
@@ -1,0 +1,51 @@
+package scrumbackend.scrum;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.sql.Date;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import scrumbackend.issue.Issue;
+import scrumbackend.task.Task;
+
+@Entity
+@Table(name = "scrums")
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Scrum {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false)
+  private Date createdAt;
+
+  @UpdateTimestamp
+  private Date updatedAt;
+
+  @OneToMany(mappedBy = "scrum")
+  private List<Task> tasks;
+
+  @OneToOne
+  @JoinColumn(name = "issue_id")
+  private Issue issue;
+}

--- a/src/main/java/scrumbackend/scrum/ScrumRepository.java
+++ b/src/main/java/scrumbackend/scrum/ScrumRepository.java
@@ -1,0 +1,9 @@
+package scrumbackend.scrum;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScrumRepository extends JpaRepository<Scrum, Long> {
+  List<Scrum> findByCreatedAtBetween(Instant from, Instant to);
+}

--- a/src/main/java/scrumbackend/task/Task.java
+++ b/src/main/java/scrumbackend/task/Task.java
@@ -14,11 +14,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import scrumbackend.user.User;
-
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import scrumbackend.scrum.Scrum;
+import scrumbackend.user.User;
 
 @Entity
 @Table(name = "tasks")
@@ -50,4 +50,8 @@ public class Task {
   @ManyToOne
   @JoinColumn(name = "user_id")
   private User user;
+
+  @ManyToOne
+  @JoinColumn(name = "scrum_id")
+  private Scrum scrum;
 }

--- a/src/main/java/scrumbackend/team/TeamRepository.java
+++ b/src/main/java/scrumbackend/team/TeamRepository.java
@@ -1,5 +1,8 @@
 package scrumbackend.team;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TeamRepository extends JpaRepository<Team, Long> {}
+public interface TeamRepository extends JpaRepository<Team, Long> {
+  Optional<Team> findByName(String name);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
 spring.datasource.username=postgres
 spring.datasource.password=admin
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.data.rest.base-path=/api
 


### PR DESCRIPTION
This commit introduces the UserDataInitializer class responsible for initializing user data. It creates users with different roles and associates them with teams if they don't already exist. The initialization includes: Creating an Example Team if it doesn't exist.
Creating a user@example.com user with the USER role and associating them with the Example Team. Creating an admin@example.com user with the ADMIN role and associating them with the Example Team. Creating an inactive@example.com user with the INACTIVE role and associating them with the Example Team. The UserDataInitializer uses the UserRepository to check for existing users by email and create new ones if they don't exist. It also utilizes the TeamRepository to find or create teams based on their names. This initialization ensures that users with different roles are available for testing and development purposes.